### PR TITLE
feat: add default globe icon for missing favicon

### DIFF
--- a/packages/browser-ui/examples/core/index.ts
+++ b/packages/browser-ui/examples/core/index.ts
@@ -109,7 +109,13 @@ function createTabElement(tabMeta: any, isActive: boolean): HTMLDivElement {
   // 根据加载状态决定显示的图标
   const iconHtml = tabMeta.isLoading
     ? `<div class="tab-loading-icon" data-tab-id="ico-${tabMeta.id}">⟳</div>`
-    : `<img class="tab-favicon" data-tab-id="ico-${tabMeta.id}" src="${tabMeta.favicon}" />`;
+    : tabMeta.favicon
+      ? `<img class="tab-favicon" data-tab-id="ico-${tabMeta.id}" src="${tabMeta.favicon}" />`
+      : `<div class="tab-favicon" data-tab-id="ico-${tabMeta.id}" style="display: flex; align-items: center; justify-content: center; background-color: #5F6368; border-radius: 50%; width: 14px; height: 14px;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="white">
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.94-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/>
+          </svg>
+        </div>`;
 
   tabElement.innerHTML = `
     ${iconHtml}


### PR DESCRIPTION
Replace broken image placeholder with a default globe icon when tabMeta.favicon is not available. The icon features:
- Gray circular background (#5F6368)
- White globe SVG icon
- Compact 13x13px size
- Consistent with browser default favicon style

🤖 Generated with [Claude Code](https://claude.com/claude-code)