### PR TITLE
fix: support chrome://new-tab-page/ in validateNavigationUrl

### DIFF
--- a/packages/browser/src/utils/url.ts
+++ b/packages/browser/src/utils/url.ts
@@ -22,7 +22,8 @@ export function validateNavigationUrl(rawUrl: string): ValidateResult {
     };
   }
 
-  if (original.toLowerCase().startsWith('chrome://newtab')) {
+  if (original.toLowerCase().startsWith('chrome://newtab') ||
+      original.toLowerCase().startsWith('chrome://new-tab-page')) {
     return { ignored: false, url: original };
   }
 


### PR DESCRIPTION
- Extend validateNavigationUrl to accept chrome://new-tab-page/ URLs
- Fixes issue where initializeExistingTabs would ignore new tab pages
- Maintains existing security by still blocking other chrome:// URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)