### PR TITLE
fix(browser-ui): restore ScreencastRenderer after browser reconnection

### DIFF
--- a/packages/browser-ui/src/core/browser.ts
+++ b/packages/browser-ui/src/core/browser.ts
@@ -197,6 +197,13 @@ export class UIBrowser {
       this.#tabs = await UITabs.UICreate(this.#pptrBrowser, this.#element, {
         viewport: this.#defaultViewport,
       });
+
+      // Restore active tab's ScreencastRenderer after reconnection
+      const activeTab = this.#tabs.getActiveTab();
+      if (activeTab) {
+        await activeTab.active();
+      }
+
       this.#reconnectAttempts = 0;
     } catch (error) {
       if (this.#reconnectAttempts < MAX_RETRIES) {


### PR DESCRIPTION
When UIBrowser.attemptReconnect() recreates the tabs instance, the active tab's ScreencastRenderer loses connection and stops working. This fix restores the active tab's ScreencastRenderer by calling activeTab.active() after successful reconnection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)