### PR TITLE
feat(browser): add path support to tab screenshot API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ vite.config.ts.timestamp-*
 .vscode/*
 !.vscode/extensions.json
 .idea
+
+# Code Agent
+.claude

--- a/packages/browser/example/browser.ts
+++ b/packages/browser/example/browser.ts
@@ -13,8 +13,12 @@ async function main() {
 
   await tab!.goto('https://bot-detector.rebrowser.net/');
   await new Promise((resolve) => setTimeout(resolve, 3000));
-  await tab!.page.screenshot({ path: './example/bot-detector.png', fullPage: true });
+  const data = await tab!.screenshot({ path: './example/bot-detector.png', fullPage: true });
 
+  // @ts-ignore
+  delete data.data;
+
+  console.log('Screenshot data:', data);
 
   await browser.close();
 }

--- a/packages/browser/src/types/tabs.ts
+++ b/packages/browser/src/types/tabs.ts
@@ -82,8 +82,23 @@ export interface NavigationOptions {
   timeout?: number;
 }
 
-// TODO: add path options
 export type TabScreenshotOptions = Pick<
   ScreenshotOptions,
-  'type' | 'quality' | 'fullPage'
+  'type' | 'quality' | 'fullPage' | 'path'
 >;
+
+export interface BaseScreenshotResult {
+  data: string;
+  type: string;
+  width: number;
+  height: number;
+}
+
+export interface ScreenshotResultWithPath extends BaseScreenshotResult {
+  absolutePath: string;
+}
+
+export type TabScreenshotResult<T extends TabScreenshotOptions> =
+  T extends { path: string }
+    ? ScreenshotResultWithPath
+    : BaseScreenshotResult;


### PR DESCRIPTION
- Add path option to TabScreenshotOptions
- Auto-detect image type from file extension
- Save screenshot to file when path provided
- Return absolute path in screenshot result
- Update types to handle conditional return type

🤖 Generated with [Claude Code](https://claude.com/claude-code)